### PR TITLE
Extend platformconfig types with BuildahConfig

### DIFF
--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -28,6 +28,26 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+const (
+	// BuilderKindDocker uses the local Docker daemon to build images
+	BuilderKindDocker = "docker"
+
+	// BuilderKindKaniko uses Kaniko to build images as a Kubernetes Job (deprecated)
+	BuilderKindKaniko = "kaniko"
+
+	// BuilderKindBuildah uses Buildah to build images as a Kubernetes Job
+	BuilderKindBuildah = "buildah"
+)
+
+// BuildahConfig holds Buildah-specific configuration for the container image builder
+type BuildahConfig struct {
+	Image         string                `json:"image,omitempty"`
+	StorageDriver string                `json:"storageDriver,omitempty"`
+	Privileged    bool                  `json:"privileged,omitempty"`
+	BuildArgs     []string              `json:"buildArgs,omitempty"`
+	Resources     v1.ResourceRequirements `json:"resources,omitempty"`
+}
+
 // BuildOptions are options for building a container image
 type BuildOptions struct {
 	Image                                  string
@@ -82,6 +102,7 @@ type ContainerBuilderConfiguration struct {
 	InsecurePullRegistry                 bool
 	PushImagesRetries                    int
 	ImageFSExtractionRetries             int
+	Buildah                              BuildahConfig
 }
 
 func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) {
@@ -162,6 +183,17 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 
 	containerBuilderConfiguration.DefaultServiceAccount = common.GetEnvOrDefaultString("NUCLIO_KANIKO_DEFAULT_SERVICE_ACCOUNT",
 		"")
+
+	if containerBuilderConfiguration.Buildah.Image == "" {
+		containerBuilderConfiguration.Buildah.Image = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_CONTAINER_IMAGE", "quay.io/buildah/stable")
+	}
+	if containerBuilderConfiguration.Buildah.StorageDriver == "" {
+		containerBuilderConfiguration.Buildah.StorageDriver = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_STORAGE_DRIVER", "vfs")
+	}
+	containerBuilderConfiguration.Buildah.Privileged = common.GetEnvOrDefaultBool(
+		"NUCLIO_BUILDAH_PRIVILEGED", false)
 
 	return &containerBuilderConfiguration, nil
 }

--- a/pkg/platformconfig/platformconfig.go
+++ b/pkg/platformconfig/platformconfig.go
@@ -188,6 +188,7 @@ func (c *Config) EnrichPlatformConfig() error {
 	utils.EnrichProbe(&c.Kube.DefaultReadinessProbe, defaultPlatformConfiguration.Kube.DefaultReadinessProbe)
 	utils.EnrichProbe(&c.Kube.DefaultLivenessProbe, defaultPlatformConfiguration.Kube.DefaultLivenessProbe)
 	c.enrichElasticSearchConfig()
+	c.enrichBuildahConfig()
 
 	return nil
 }
@@ -508,6 +509,27 @@ func (c *Config) enrichElasticSearchConfig() {
 	// override with environment variable if set
 	if envPassword := os.Getenv("NUCLIO_ELASTIC_SEARCH_PASSWORD"); envPassword != "" {
 		c.Kube.ElasticSearchConfig.Password = envPassword
+	}
+}
+
+func (c *Config) enrichBuildahConfig() {
+	if c.Kube.Builder.Buildah.Image == "" {
+		c.Kube.Builder.Buildah.Image = DefaultBuildahImage
+	}
+	if c.Kube.Builder.Buildah.StorageDriver == "" {
+		c.Kube.Builder.Buildah.StorageDriver = DefaultBuildahStorageDriver
+	}
+	if c.Kube.Builder.Buildah.Resources.Requests == nil {
+		c.Kube.Builder.Buildah.Resources.Requests = v1.ResourceList{
+			v1.ResourceCPU:    apiresource.MustParse("500m"),
+			v1.ResourceMemory: apiresource.MustParse("1Gi"),
+		}
+	}
+	if c.Kube.Builder.Buildah.Resources.Limits == nil {
+		c.Kube.Builder.Buildah.Resources.Limits = v1.ResourceList{
+			v1.ResourceCPU:    apiresource.MustParse("2"),
+			v1.ResourceMemory: apiresource.MustParse("4Gi"),
+		}
 	}
 }
 

--- a/pkg/platformconfig/types.go
+++ b/pkg/platformconfig/types.go
@@ -136,6 +136,29 @@ const (
 	AutoScaleMetricsModeCustom AutoScaleMetricsMode = "custom"
 )
 
+type BuilderMode string
+
+const (
+	BuilderModeDocker  BuilderMode = "docker"
+	BuilderModeKaniko  BuilderMode = "kaniko"
+	BuilderModeBuildah BuilderMode = "buildah"
+)
+
+// BuildahConfig holds configuration for the Buildah container image builder.
+type BuildahConfig struct {
+	Image         string                      `json:"image,omitempty"`
+	StorageDriver string                      `json:"storageDriver,omitempty"`
+	Privileged    bool                        `json:"privileged,omitempty"`
+	BuildArgs     []string                    `json:"buildArgs,omitempty"`
+	Resources     corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+// BuilderConfig configures which container image builder to use for function builds.
+type BuilderConfig struct {
+	Mode    BuilderMode  `json:"mode,omitempty"`
+	Buildah BuildahConfig `json:"buildah,omitempty"`
+}
+
 func AutoScaleMetricsModeIsValid(autoScaleMode AutoScaleMetricsMode) bool {
 	for _, mode := range []AutoScaleMetricsMode{
 		AutoScaleMetricsModeLegacy,
@@ -205,6 +228,7 @@ type PlatformKubeConfig struct {
 	ProjectSecretTemplate                  string                  `json:"projectSecretTemplate,omitempty"`
 	ProjectSecretAllowedServiceAccountsKey string                  `json:"projectSecretAllowedServiceAccountsKey,omitempty"`
 	ProjectSecretDefaultServiceAccountKey  string                  `json:"projectSecretDefaultServiceAccountKey,omitempty"`
+	Builder                                BuilderConfig           `json:"builder,omitempty"`
 }
 
 // IsConfiguredToVerifyServiceAccountFromProject checks if the platform kube config is configured to verify service accounts
@@ -351,6 +375,9 @@ const (
 	DefaultStreamMonitoringWebapiURL = "http://v3io-webapi:8081"
 	DefaultV3ioRequestConcurrency    = 64
 	DefaultHTTPIngressClassName      = "nginx"
+
+	DefaultBuildahImage         = "quay.io/buildah/stable"
+	DefaultBuildahStorageDriver = "vfs"
 )
 
 type StreamMonitoringConfig struct {


### PR DESCRIPTION
Add a `BuildahConfig` struct to `pkg/platformconfig/types.go` containing fields: `Image` (string, default `quay.io/buildah/stable`), `StorageDriver` (string, default `vfs`), `Privileged` (bool, default false), `BuildArgs` ([]string), and `Resources` (corev1.ResourceRequirements). Extend the existing `BuilderConfig` struct to include a `Buildah BuildahConfig` field and add `"buildah"` as a valid builder mode constant. Set sensible defaults in `config.go`. No logic changes — types and defaults only.

