### PR TITLE
chore: bump golangci-lint from v2.5.0 to v2.12.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -699,7 +699,7 @@ ensure-test-files-annotated:
 	@echo "All go test files have //go:build test_X annotation"
 	@exit $(.SHELLSTATUS)
 
-GOLANGCI_LINT_VERSION := 2.5.0
+GOLANGCI_LINT_VERSION := 2.12.2
 GOLANGCI_LINT_BIN := $(CURDIR)/.bin/golangci-lint
 GOLANGCI_LINT_INSTALL_COMMAND := GOBIN=$(CURDIR)/.bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 


### PR DESCRIPTION
## Summary
- Update `GOLANGCI_LINT_VERSION` in `Makefile` from `2.5.0` to `2.12.2` (latest stable release)
- Version remains explicitly pinned — no floating `latest` tag

## Traceability
Work item: WI-38BA0B-2

## Test plan
- [ ] Confirm `make lint` installs and runs golangci-lint v2.12.2 without errors
- [ ] CI pipeline passes with the updated version

🤖 Generated with [Claude Code](https://claude.com/claude-code)