### PR TITLE
Bump Alpine base image from 3.20 to 3.23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,17 +94,17 @@ endif
 
 # alpine is commonly used by controller / dlx / autoscaler
 ifeq ($(NUCLIO_ARCH), armhf)
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm32v7/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm32v7/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm32v7/node:20
 else ifeq ($(NUCLIO_ARCH), arm64)
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/arm64v8/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/arm64v8/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK 		?= gcr.io/iguazio/arm64v8/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/arm64v8/node:20
 else
-	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.20
+	NUCLIO_DOCKER_ALPINE_IMAGE 		?= gcr.io/iguazio/alpine:3.23
 	NUCLIO_BASE_IMAGE_NAME 			?= gcr.io/iguazio/golang
 	NUCLIO_DOCKER_JAVA_OPENJDK		?= gcr.io/iguazio/openjdk:11-jdk-slim-bullseye
 	NODE_IMAGE_NAME 				?= gcr.io/iguazio/node:20

--- a/docs/reference/runtimes/golang/golang-reference.md
+++ b/docs/reference/runtimes/golang/golang-reference.md
@@ -30,7 +30,7 @@ See [Deploying Functions from a Dockerfile](../../../tasks/deploy-functions-from
 ```
 ARG NUCLIO_LABEL=0.5.6
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=alpine:3.20
+ARG NUCLIO_BASE_IMAGE=alpine:3.23
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}-alpine
 
 # Supplies processor uhttpc, used for healthcheck

--- a/docs/tasks/deploy-functions-from-dockerfile.md
+++ b/docs/tasks/deploy-functions-from-dockerfile.md
@@ -39,7 +39,7 @@ The Dockerfile will look something like this:
 ```
 ARG NUCLIO_LABEL=latest
 ARG NUCLIO_ARCH=amd64
-ARG NUCLIO_BASE_IMAGE=alpine:3.20
+ARG NUCLIO_BASE_IMAGE=alpine:3.23
 ARG NUCLIO_ONBUILD_IMAGE=nuclio/handler-builder-golang-onbuild:${NUCLIO_LABEL}-${NUCLIO_ARCH}-alpine
 
 # Supplies processor uhttpc, used for healthcheck
@@ -66,7 +66,7 @@ CMD [ "processor" ]
 This multi-stage Dockerfile uses three `FROM` directives:
 
 1. `FROM nuclio/uhttpc:0.0.3-amd64` - used for providing an [open-source health-check related binary](https://github.com/nuclio/uhttpc) (basically, a self contained curl). This is used for the "local" platform. You don't need this or the `HEALTHCHECK` platform if you plan on running only on Kubernetes.
-2. `FROM alpine:3.20` - the base image on which the final processor image will run.
+2. `FROM alpine:3.23` - the base image on which the final processor image will run.
 3. `FROM nuclio/handler-builder-golang-onbuild` - this is where it gets interesting: while every runtime needs the processor binary, each runtime must also provide a unique set of artifacts. Interpreter-based runtimes, like Python and NodeJS, simply need to provide the shim layer and the user's code. However, compiled runtimes (Go, Java, .NET Core) must compile the user's code into a binary. This is done with a set of `ONBUILD` directives in the `onbuild` image. You provide the source, and the base image will do everything that is required to provide you with the artifact at the expected location. In this tutorial, by simply using `FROM nuclio/handler-builder-golang-onbuild` and providing Go source code, you will build a Go plugin that will reside at `/opt/nuclio/handler.so`. All you have to do is copy the plugin to the proper location in you final processor image.
 
 It is up to you to customize this Dockerfile, if you so choose (for example, by adding `RUN` directives that add dependencies), but all provided Dockerfiles are ready to go. Go ahead and build the function; you only need the **Dockerfile** and **helloworld.go**:

--- a/pkg/platform/local/platform.go
+++ b/pkg/platform/local/platform.go
@@ -110,11 +110,11 @@ func NewPlatform(ctx context.Context,
 
 	switch runtime.GOARCH {
 	case "arm64":
-		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/arm64v8/alpine:3.23"
 	case "arm":
-		newPlatform.storeImageName = "gcr.io/iguazio/arm32v7/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/arm32v7/alpine:3.23"
 	default:
-		newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.20"
+		newPlatform.storeImageName = "gcr.io/iguazio/alpine:3.23"
 	}
 
 	if newPlatform.ContainerBuilder, err = containerimagebuilderpusher.NewDocker(newPlatform.Logger,

--- a/pkg/processor/build/runtime/golang/runtime.go
+++ b/pkg/processor/build/runtime/golang/runtime.go
@@ -63,7 +63,7 @@ func (g *golang) GetName() string {
 func (g *golang) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, onbuildImageRegistry string) (*runtime.ProcessorDockerfileInfo, error) {
 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{
-		BaseImage: "gcr.io/iguazio/alpine:3.20",
+		BaseImage: "gcr.io/iguazio/alpine:3.23",
 	}
 
 	// if the base image is not default (which is alpine) and is not alpine based, must use the non-alpine onbuild image

--- a/pkg/processor/build/runtime/shell/runtime.go
+++ b/pkg/processor/build/runtime/shell/runtime.go
@@ -38,7 +38,7 @@ func (s *shell) GetProcessorDockerfileInfo(runtimeConfig *runtimeconfig.Config, 
 	processorDockerfileInfo := runtime.ProcessorDockerfileInfo{}
 
 	// set the default base image
-	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/alpine:3.20"
+	processorDockerfileInfo.BaseImage = "gcr.io/iguazio/alpine:3.23"
 
 	// fill onbuild artifact
 	artifact := runtime.Artifact{


### PR DESCRIPTION
## Summary

- Updates all `alpine:3.20` image references to `alpine:3.23` across Makefile, Go runtime constants, and documentation examples
- No pinned `apk` package versions were found — no unpinning needed
- No logic changes; strictly a version string bump

Traceability: WI-66B439-1

## Changes

| File | Change |
|------|--------|
| `Makefile` | `NUCLIO_DOCKER_ALPINE_IMAGE` for all 3 arch variants (amd64, arm64, armhf) |
| `pkg/platform/local/platform.go` | `storeImageName` constants for all 3 arches |
| `pkg/processor/build/runtime/golang/runtime.go` | `BaseImage` default |
| `pkg/processor/build/runtime/shell/runtime.go` | `BaseImage` default |
| `docs/tasks/deploy-functions-from-dockerfile.md` | Example Dockerfile snippet |
| `docs/reference/runtimes/golang/golang-reference.md` | Example Dockerfile snippet |

## Test plan

- [ ] Verify `grep -r alpine:3.20 .` returns no matches
- [ ] Run CI suite to confirm container builds succeed with Alpine 3.23
- [ ] Confirm no `apk add` failures due to changed package availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)