### PR TITLE
Add ImagePullSecrets field to FunctionConfig Build struct

### DIFF
--- a/pkg/functionconfig/types.go
+++ b/pkg/functionconfig/types.go
@@ -446,6 +446,7 @@ type Build struct {
 	TempDir               string                 `json:"tempDir,omitempty"`
 	Registry              string                 `json:"registry,omitempty"`
 	BaseImageRegistry     string                 `json:"baseImageRegistry,omitempty"`
+	ImagePullSecrets      []string               `json:"imagePullSecrets,omitempty"`
 	Image                 string                 `json:"image,omitempty"`
 	NoBaseImagesPull      bool                   `json:"noBaseImagesPull,omitempty"`
 	NoCache               bool                   `json:"noCache,omitempty"`


### PR DESCRIPTION
**Type:** Feature — data model extension

**Goal:** Add `ImagePullSecrets []string` to the `Build` struct in `pkg/functionconfig/types.go` so the function spec can express an ordered list of Kubernetes secret names for Docker auth.

**Scope / files changed:**
- `pkg/functionconfig/types.go` — add `ImagePullSecrets []string \`json:"imagePullSecrets,omitempty"\`` to the `Build` struct.

**Implementation details:**
- Field placed alongside other registry-related fields in `Build`.
- `omitempty` ensures zero-value (nil slice) is not serialised, preserving backward compatibility with existing stored specs.
- No migration needed; unmarshalling an old spec without the field yields a nil slice, which the builder treats as "no secrets listed".

**Interfaces touched:** `functionconfig.Build` (public struct — read by all builders, but only the Kaniko path will act on the new field).

**Acceptance criteria:**
- `Build` struct compiles with the new field.
- Existing unit tests in `pkg/functionconfig/` continue to pass.
- JSON round-trip of a spec without `imagePullSecrets` produces no new keys.

**Risk level:** Low — additive struct field, no logic change.

_Work item: WI-673282-1_

Opened by the Demerzel implement agent.