### PR TITLE
Add AGENTS.md to repository root

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# AGENTS.md — nuclio
+
+Authoritative reference for AI coding agents working in the nuclio repository.
+Human-curated; update when Makefile targets or conventions change.
+
+---
+
+## Project Overview
+
+nuclio is a high-performance, open-source serverless event and data processing
+platform. The codebase is primarily Go, with some Python and Shell. The main
+integration branch is **`development`**; all feature work branches from it.
+`master` tracks the latest stable release. Full contributor docs live in
+[`docs/devel/contributing.md`](docs/devel/contributing.md).
+
+---
+
+## Build Commands
+
+```sh
+make modules       # fetch Go dependencies (run first in a clean checkout)
+make build         # build all Docker images and the nuctl CLI
+make nuctl-bin     # build nuctl binary only — no Docker required
+make fmt lint      # format and lint; run before every commit
+```
+
+---
+
+## Test Commands
+
+```sh
+make lint test-unit   # fast unit tests (~seconds) — required before every PR
+make test             # local integration tests (~90 min, requires Docker)
+```
+
+**Notes**:
+- Unit tests require build tag `test_unit`; integration tests use `test_integration`.
+- Linter: `golangci-lint` v2.x — config is [`.golangci.yml`](.golangci.yml).
+- `make lint` also verifies all test files carry the correct build-tag annotation.
+
+---
+
+## Coding Conventions
+
+Distilled from [`docs/devel/coding-conventions.md`](docs/devel/coding-conventions.md).
+
+### Naming
+- Use **verbose, descriptive names**: `handleFunctionAdd` not `add`; `handler` not `hdlr`.
+- Short names are acceptable only for struct receivers (e.g., `f` for a `Function` receiver).
+- File variable suffix conventions:
+  - `FileName` — base name only
+  - `Dir` — directory path
+  - `Path` — full absolute or relative path
+  - `File` — `*os.File` object
+  - `FileContents` — contents read from a file
+
+### Structure
+- All functionality lives in **instantiatable objects**; no package-level mutable state.
+- Exported struct methods must appear **before** unexported ones.
+
+### Testing
+- Tests use **testify suites** (`github.com/stretchr/testify/suite`).
+- All assertions go through `suite.Require().<Assertion>` (not `assert`).
+- Test suite ordering: struct → `SetupSuite` → `SetupTest` → `TearDownTest` →
+  `TearDownSuite` → test functions → helper functions.
+
+---
+
+## Branching & PR Conventions
+
+1. **Fork** the repository; do **not** push feature branches to `nuclio/nuclio` directly.
+2. Branch from `development` (not `master` or `main`).
+3. Run `make fmt lint` before opening a PR.
+4. PR description must explain **why** the change is needed, not just what changed.
+5. GitHub Actions CI validates every PR — do not merge until all checks pass.
+
+---
+
+## Boundaries — Ask a Human First
+
+| Action | Policy |
+|--------|--------|
+| Force-push to `development` or `master` | **Never** |
+| Commit built binaries or Docker images | **Never** |
+| Add a new Go module dependency | Ask first |
+| Modify CI workflow files under `.github/` | Ask first |
+| Introduce a new package-level variable with mutable state | Ask first |


### PR DESCRIPTION
## Type
Documentation / Developer Experience

## Goal
Create `AGENTS.md` at the root of the nuclio repository so that all AGENTS.md-aware AI coding tools have an authoritative, session-persistent reference for building, testing, and contributing to nuclio.

## Scope
Single new file: `/AGENTS.md`

## Implementation Details

The file will contain these sections (≤150 lines total):

1. **Project Overview** — one paragraph describing nuclio (high-performance serverless event/data processing, primarily Go); states `development` is the main integration branch.
2. **Build Commands** — fenced block with `make modules`, `make build`, `make nuctl-bin`, `make fmt lint`.
3. **Test Commands** — fenced block with `make lint test-unit` (fast, run before every PR) and `make test` (integration, ~90 min); notes build tags (`test_unit`, `test_integration`) and golangci-lint v2.x / `.golangci.yml`.
4. **Coding Conventions** — bullet list distilled from `docs/devel/coding-conventions.md`: verbose names, instantiatable objects only, exported-before-unexported methods, file variable suffixes, testify suite pattern, test ordering.
5. **Branching & PR Conventions** — fork → branch from `development` → `make fmt lint` → PR with "why" description → GitHub Actions CI validates.
6. **Boundaries** — never force-push `development`/`master`; never commit binaries/images; ask before adding Go module deps; ask before touching `.github/` workflows.

## Files Produced
- `AGENTS.md` (new, repo root)

## Acceptance Criteria
- File exists at repo root
- ≤150 lines
- All commands match current Makefile targets (verified against `/workspace/Makefile`)
- All referenced paths (`docs/devel/coding-conventions.md`, `docs/devel/contributing.md`, `.golangci.yml`) exist in the repo
- PR targets `development` branch

## Risk Level
Low — documentation-only change, no code modified.

## Why this repo
nuclio-fork is the only available repository and is the target codebase.

_Work item: WI-FC02F3-1_

Opened by the Demerzel implement agent.