### PR TITLE
Config types: Buildah fields in ContainerBuilderConfiguration

### DIFF
--- a/pkg/containerimagebuilderpusher/types.go
+++ b/pkg/containerimagebuilderpusher/types.go
@@ -82,6 +82,16 @@ type ContainerBuilderConfiguration struct {
 	InsecurePullRegistry                 bool
 	PushImagesRetries                    int
 	ImageFSExtractionRetries             int
+
+	// Buildah-specific fields
+	BuildahImage              string
+	BuildahImagePullPolicy    string
+	BuildahStorageDriver      string
+	BuildahIsolation          string
+	BuildahPrivileged         bool
+	BuildahJobPrefix          string
+	BuildahJobDeletionTimeout time.Duration
+	BuildahPushImagesRetries  int
 }
 
 func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) {
@@ -162,6 +172,39 @@ func NewContainerBuilderConfiguration() (*ContainerBuilderConfiguration, error) 
 
 	containerBuilderConfiguration.DefaultServiceAccount = common.GetEnvOrDefaultString("NUCLIO_KANIKO_DEFAULT_SERVICE_ACCOUNT",
 		"")
+
+	if containerBuilderConfiguration.BuildahImage == "" {
+		containerBuilderConfiguration.BuildahImage = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_CONTAINER_IMAGE", "quay.io/buildah/stable:latest")
+	}
+	if containerBuilderConfiguration.BuildahImagePullPolicy == "" {
+		containerBuilderConfiguration.BuildahImagePullPolicy = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_CONTAINER_IMAGE_PULL_POLICY", "IfNotPresent")
+	}
+	if containerBuilderConfiguration.BuildahStorageDriver == "" {
+		containerBuilderConfiguration.BuildahStorageDriver = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_STORAGE_DRIVER", "overlay")
+	}
+	if containerBuilderConfiguration.BuildahIsolation == "" {
+		containerBuilderConfiguration.BuildahIsolation = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_ISOLATION", "chroot")
+	}
+	containerBuilderConfiguration.BuildahPrivileged =
+		common.GetEnvOrDefaultBool("NUCLIO_BUILDAH_PRIVILEGED", false)
+	if containerBuilderConfiguration.BuildahJobPrefix == "" {
+		containerBuilderConfiguration.BuildahJobPrefix = common.GetEnvOrDefaultString(
+			"NUCLIO_BUILDAH_JOB_NAME_PREFIX", "buildahjob")
+	}
+	containerBuilderConfiguration.BuildahPushImagesRetries, err =
+		strconv.Atoi(common.GetEnvOrDefaultString("NUCLIO_BUILDAH_PUSH_IMAGES_RETRIES", "3"))
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to resolve Buildah push retries")
+	}
+	buildahJobDeletionTimeout := common.GetEnvOrDefaultString("NUCLIO_BUILDAH_JOB_DELETION_TIMEOUT", "30m")
+	containerBuilderConfiguration.BuildahJobDeletionTimeout, err = time.ParseDuration(buildahJobDeletionTimeout)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to parse Buildah job deletion timeout")
+	}
 
 	return &containerBuilderConfiguration, nil
 }

--- a/pkg/containerimagebuilderpusher/types_test.go
+++ b/pkg/containerimagebuilderpusher/types_test.go
@@ -1,0 +1,86 @@
+//go:build test_unit
+
+/*
+Copyright 2023 The Nuclio Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package containerimagebuilderpusher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type ContainerBuilderConfigurationTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestBuildahDefaults() {
+	cfg, err := NewContainerBuilderConfiguration()
+	suite.Require().NoError(err)
+
+	suite.Equal("quay.io/buildah/stable:latest", cfg.BuildahImage)
+	suite.Equal("IfNotPresent", cfg.BuildahImagePullPolicy)
+	suite.Equal("overlay", cfg.BuildahStorageDriver)
+	suite.Equal("chroot", cfg.BuildahIsolation)
+	suite.Equal(false, cfg.BuildahPrivileged)
+	suite.Equal("buildahjob", cfg.BuildahJobPrefix)
+	suite.Equal(30*time.Minute, cfg.BuildahJobDeletionTimeout)
+	suite.Equal(3, cfg.BuildahPushImagesRetries)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestBuildahEnvVarOverrides() {
+	suite.T().Setenv("NUCLIO_BUILDAH_CONTAINER_IMAGE", "quay.io/buildah/stable:v1.33.0")
+	suite.T().Setenv("NUCLIO_BUILDAH_CONTAINER_IMAGE_PULL_POLICY", "Always")
+	suite.T().Setenv("NUCLIO_BUILDAH_STORAGE_DRIVER", "vfs")
+	suite.T().Setenv("NUCLIO_BUILDAH_ISOLATION", "rootless")
+	suite.T().Setenv("NUCLIO_BUILDAH_PRIVILEGED", "true")
+	suite.T().Setenv("NUCLIO_BUILDAH_JOB_NAME_PREFIX", "mybuildahjob")
+	suite.T().Setenv("NUCLIO_BUILDAH_JOB_DELETION_TIMEOUT", "15m")
+	suite.T().Setenv("NUCLIO_BUILDAH_PUSH_IMAGES_RETRIES", "5")
+
+	cfg, err := NewContainerBuilderConfiguration()
+	suite.Require().NoError(err)
+
+	suite.Equal("quay.io/buildah/stable:v1.33.0", cfg.BuildahImage)
+	suite.Equal("Always", cfg.BuildahImagePullPolicy)
+	suite.Equal("vfs", cfg.BuildahStorageDriver)
+	suite.Equal("rootless", cfg.BuildahIsolation)
+	suite.Equal(true, cfg.BuildahPrivileged)
+	suite.Equal("mybuildahjob", cfg.BuildahJobPrefix)
+	suite.Equal(15*time.Minute, cfg.BuildahJobDeletionTimeout)
+	suite.Equal(5, cfg.BuildahPushImagesRetries)
+}
+
+func (suite *ContainerBuilderConfigurationTestSuite) TestExistingKanikoFieldsUnchanged() {
+	cfg, err := NewContainerBuilderConfiguration()
+	suite.Require().NoError(err)
+
+	// Verify existing Kaniko defaults remain intact
+	suite.Equal("docker", cfg.Kind)
+	suite.Equal("busybox:stable", cfg.BusyBoxImage)
+	suite.Equal("gcr.io/kaniko-project/executor:v1.23.2", cfg.KanikoImage)
+	suite.Equal("IfNotPresent", cfg.KanikoImagePullPolicy)
+	suite.Equal("kanikojob", cfg.JobPrefix)
+	suite.Equal(30*time.Minute, cfg.JobDeletionTimeout)
+	suite.Equal(3, cfg.PushImagesRetries)
+	suite.Equal(3, cfg.ImageFSExtractionRetries)
+}
+
+func TestContainerBuilderConfigurationTestSuite(t *testing.T) {
+	suite.Run(t, new(ContainerBuilderConfigurationTestSuite))
+}


### PR DESCRIPTION
## Type: Implementation

### Goal
Add Buildah-specific configuration fields to `ContainerBuilderConfiguration` and load them from environment variables in `NewContainerBuilderConfiguration()`.

### Files Changed
- `pkg/containerimagebuilderpusher/types.go` — additive struct fields + env var loading
- `pkg/containerimagebuilderpusher/types_test.go` (or existing test file) — unit tests for new defaults and env var overrides

### Implementation Details

Add 8 fields to `ContainerBuilderConfiguration`:
```go
BuildahImage              string
BuildahImagePullPolicy    string
BuildahStorageDriver      string
BuildahIsolation          string
BuildahPrivileged         bool
BuildahJobPrefix          string
BuildahJobDeletionTimeout time.Duration
BuildahPushImagesRetries  int
```

Add env var loading in `NewContainerBuilderConfiguration()` for:
- `NUCLIO_BUILDAH_CONTAINER_IMAGE` → `quay.io/buildah/stable:latest`
- `NUCLIO_BUILDAH_CONTAINER_IMAGE_PULL_POLICY` → `IfNotPresent`
- `NUCLIO_BUILDAH_STORAGE_DRIVER` → `overlay`
- `NUCLIO_BUILDAH_ISOLATION` → `chroot`
- `NUCLIO_BUILDAH_PRIVILEGED` → `false`
- `NUCLIO_BUILDAH_JOB_NAME_PREFIX` → `buildahjob`
- `NUCLIO_BUILDAH_JOB_DELETION_TIMEOUT` → `30m`
- `NUCLIO_BUILDAH_PUSH_IMAGES_RETRIES` → `3`

No existing fields or loading logic may be modified. All existing Kaniko/Docker env var loading must remain untouched.

### Why This Repo
`nuclio` is the only repository; `types.go` is the canonical configuration struct for the builder subsystem.

_Work item: WI-AD7ED4-1_

Opened by the Iggy implement agent.